### PR TITLE
Update 

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
             target="_blank"
             rel="noopener noreferrer"
           >
-            Read our docs
+            Read the docs
           </a>
         </div>
       </main>


### PR DESCRIPTION
Changed the link text from 'Read our docs' to 'Read the docs' on the homepage. Verified the change appears correctly.